### PR TITLE
Implement AOS-61 Add object mode check for operations

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -14,10 +14,6 @@ import (
 )
 
 func (s *Storage) completeMultipart(ctx context.Context, o *Object, parts []*Part, opt pairStorageCompleteMultipart) (err error) {
-	if o.Mode&ModePart == 0 {
-		return services.ObjectModeInvalidError{Expected: ModePart, Actual: o.Mode}
-	}
-
 	upload := &s3.CompletedMultipartUpload{}
 	for _, v := range parts {
 		upload.Parts = append(upload.Parts, &s3.CompletedPart{
@@ -205,10 +201,6 @@ func (s *Storage) list(ctx context.Context, path string, opt pairStorageList) (o
 }
 
 func (s *Storage) listMultipart(ctx context.Context, o *Object, opt pairStorageListMultipart) (pi *PartIterator, err error) {
-	if o.Mode&ModePart == 0 {
-		return nil, services.ObjectModeInvalidError{Expected: ModePart, Actual: o.Mode}
-	}
-
 	input := &partPageStatus{
 		maxParts: 200,
 		key:      o.ID,
@@ -550,10 +542,6 @@ func (s *Storage) write(ctx context.Context, path string, r io.Reader, size int6
 }
 
 func (s *Storage) writeMultipart(ctx context.Context, o *Object, r io.Reader, size int64, index int, opt pairStorageWriteMultipart) (n int64, part *Part, err error) {
-	if o.Mode&ModePart == 0 {
-		return 0, nil, services.ObjectModeInvalidError{Expected: ModePart, Actual: o.Mode}
-	}
-
 	input := &s3.UploadPartInput{
 		Bucket: &s.name,
 		// For S3, the `PartNumber` is [1, 10000]. But for users, the `PartNumber` is zero-based.


### PR DESCRIPTION
Unify object mode check in generated.go, remove redundant check in specific actions.

Signed-off-by: Prnyself <281239768@qq.com>